### PR TITLE
Fixes reset bug by using pre-start lifecycle instead of bogus value

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ The above will split when entering Noblecourt the first time.
 Note that you will likely need a different layout for each category, to store different autosplitter settings. Testing needed, and can possibly be improved.
 
 ### Options
-- Start: Will start the timer on character selection
-- Reset: If timer is running, will reset if you hover a character in New Game character selection.
+- Start: Will start the timer when starting a character story
+- Reset: If timer is running, will reset if you start a new character story
 - Split: If timer is running, will split on anything enabled in settings.
 
 ### Split Options

--- a/octopath.asl
+++ b/octopath.asl
@@ -527,9 +527,8 @@ start {
 }
 
 reset {
-  if (timer.CurrentPhase == TimerPhase.Running &&
-      current.characterIsHighlighted == 1 &&
-      old.characterIsHighlighted == 0 &&
+  if (old.start == 0 &&
+      current.start == 1 &&
       current.zoneID == 0) {
     return true;
   }

--- a/octopath.asl
+++ b/octopath.asl
@@ -1,7 +1,5 @@
 state("Octopath_Traveler-Win64-Shipping", "Steam") {
   int start: 0x2B32C48, 0xE30;
-  int characterIsHighlighted: 0x289D268, 0x368, 0x0, 0x328;
-
   int zoneID: 0x289D240, 0x36C;
   int money: 0x0289CC48, 0x370, 0x158;
   int gameState: 0x0289D270, 0x36C;
@@ -21,8 +19,6 @@ state("Octopath_Traveler-Win64-Shipping", "Steam") {
 
 state("Octopath_Traveler-Win64-Shipping", "Xbox") {
   int start: 0x031C1FB0, 0x18, 0x700;
-  int characterIsHighlighted: 0x0302AF18, 0x240, 0x0, 0x358;
-
   int zoneID: 0x0302AEF0, 0x244;
   int money: 0x0302A8E8, 0x280, 0x150;
   int gameState: 0x0302AF20, 0x244;


### PR DESCRIPTION
closes #27 

The major behaviour change here is that since the autosplitter now relies on lifecycles, it will only split while the timer is running.